### PR TITLE
CloudFormation service role validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ jspm_packages
 # ESBuild directories
 .build
 *.js
+*.map
+
 
 # Coverage reports
 coverage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A [Serverless framework](https://www.serverless.com) plugin to enforce various f
 | --- | --- | --- |
 | Service name must be dash delimited | this-is-a-good-name | thisIsABadName |
 | Service name must not contain the word "service" | this-is-a-good-name | this-is-a-bad-service | 
+| Service provider must contain a valid cloud formation role | iam:<br>&nbsp;deploymentRole: arn:aws:iam::############:role/valid.serverless | iam:<br>&nbsp;deploymentRole: arn:aws:iam::##:role/not-valid
 | Handler names must have the same name as the function | functions:<br>&nbsp;thisIsAWellNamedExample:<br>&nbsp;&nbsp;handler: src/this-is-a-well-named-example.handler | functions:<br>&nbsp;thisIsABadlyNamedFunction:<br>&nbsp;&nbsp;handler: src/this-is-a-badly-named-example.handler |
 | Function names must be in camel case | thisIsAWellNamedExample | ThisIsABadlyNamedExample |
 | Handler names must be dash delimited | src/this-is-a-well-named-example.handler | src/ThisIsABadlyNamedExample.handler |

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 60,
-        "functions": 60,
-        "lines": 60,
-        "statements": 60
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
       }
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,13 @@ export class ServerlessConventions {
           let errors: Array<string> = []
 
           errors = errors.concat(this.checkServiceName(this.serverless.service));
+          errors = errors.concat(this.checkIAMDeploymentRole(this.serverless.service));
+          console.log(JSON.stringify(this.serverless.service.provider));
 
           const functionNames = this.serverless.service.getAllFunctions();
           functionNames.forEach(fnName => {
                const fn = this.serverless.service.getFunction(fnName) as Serverless.FunctionDefinitionHandler;
-
+               
                errors = errors.concat(this.checkHandlerName(fn));
                errors = errors.concat(this.checkFunctionName(fn));
                errors = errors.concat(this.checkHandlerNameMatchesFunction(fn));
@@ -66,6 +68,19 @@ export class ServerlessConventions {
           }
 
           return errors;
+     }
+
+     // Cloud formation service role validation
+     // Confirm that the service contains an iam deployment role
+     checkIAMDeploymentRole(service: Service) : Array<string> {
+          let errors : Array<string> = [];
+          const roles = service.provider;
+
+          errors.push(JSON.stringify(roles));
+          console.log(JSON.stringify(roles));
+          errors.push(`Warning: Service provider must contain a cloud formation service role`)
+
+          return errors; 
      }
 
      // Handler name conventions

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export class ServerlessConventions {
           const functionNames = this.serverless.service.getAllFunctions();
           functionNames.forEach(fnName => {
                const fn = this.serverless.service.getFunction(fnName) as Serverless.FunctionDefinitionHandler;
-               
+
                errors = errors.concat(this.checkHandlerName(fn));
                errors = errors.concat(this.checkFunctionName(fn));
                errors = errors.concat(this.checkHandlerNameMatchesFunction(fn));
@@ -42,10 +42,10 @@ export class ServerlessConventions {
                errors.forEach(error => {
                     this.serverless.cli.log(chalk.red(error));
                });
-               
+
                throw Error('Serverless conventions validation failed');
           }
-          
+
           this.serverless.cli.log(chalk.green('Function check complete! No errors were found.'));
      }
 
@@ -78,8 +78,8 @@ export class ServerlessConventions {
           // This is a bit of a messy way to get the iam
           // Ideally it would be typed in @types/serverless
           const iam = (<any>service.provider).iam;
-          
-          if (iam === undefined || iam === null) {
+
+          if (iam == null) {
                errors.push(`Warning: Service provider is missing a valid cloud formation service role`);
           } else {
                const deployRole = iam.deploymentRole as string;
@@ -89,7 +89,7 @@ export class ServerlessConventions {
                }
           }
 
-          return errors; 
+          return errors;
      }
 
      // Handler name conventions

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -26,8 +26,11 @@ describe('Test conventions plugin', () => {
         name: 'aws',
         stage: 'test',
         region: 'ap-southeast-2',
-        versionFunctions: false
-    }
+        versionFunctions: false,
+        iam: {
+            deploymentRole: 'arn:aws:iam::185310451239:role/example.serverless' // This is not a working CFN role
+        }
+    } as any
 
     // A good function and handler name
     let fn : Serverless.FunctionDefinitionHandler = {
@@ -107,15 +110,29 @@ describe('Test conventions plugin', () => {
     describe('Test cloudformation validation checker', () => {
         test('Cloud formation service role does not exist', async () => {
             // Does not exist
-            
+            (<any>serverless.service.provider).iam = undefined;
 
             let errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
-            expect(errors.pop()).toMatch('must contain a cloud formation service role');
+            expect(errors.pop()).toMatch('missing a valid cloud formation service role');
+        });
+
+        test('Cloud formation service role is invalid', async () => {
+            // Typo in the arn (not enough numbers)
+            (<any>serverless.service.provider).iam = { deploymentRole: 'arn:aws:iam::1554:role/example.serverless' };
+
+            let errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
+            expect(errors.pop()).toMatch('must contain a valid cloud formation service role');
+
+            // Using a user instead of a role
+            (<any>serverless.service.provider).iam = { deploymentRole: 'arn:aws:iam::185310451239:user/example.serverless' };
+
+            errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
+            expect(errors.pop()).toMatch('must contain a valid cloud formation service role');
         });
 
         test('Cloud formation service role exists', async () => {
-            // Exists
-
+            // Exists and is valid
+            (<any>serverless.service.provider).iam = { deploymentRole: 'arn:aws:iam::185917455239:role/example.serverless' };
 
             let errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
             expect(errors.length).toBe(0);

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -18,6 +18,16 @@ describe('Test conventions plugin', () => {
     serverless.service.provider.stage = 'test';
     // Return a service name
     serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
+    // Set some basic provider information
+    serverless.service.provider = {
+        compiledCloudFormationTemplate: {
+            Resources: {}
+        },
+        name: 'aws',
+        stage: 'test',
+        region: 'ap-southeast-2',
+        versionFunctions: false
+    }
 
     // A good function and handler name
     let fn : Serverless.FunctionDefinitionHandler = {
@@ -90,6 +100,24 @@ describe('Test conventions plugin', () => {
             // Valid service name
             serverless.service.getServiceName = function () { return 'test-name' };
             let errors = ServerlessConvention.checkServiceName(serverless.service);
+            expect(errors.length).toBe(0);
+        });
+    });
+
+    describe('Test cloudformation validation checker', () => {
+        test('Cloud formation service role does not exist', async () => {
+            // Does not exist
+            
+
+            let errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
+            expect(errors.pop()).toMatch('must contain a cloud formation service role');
+        });
+
+        test('Cloud formation service role exists', async () => {
+            // Exists
+
+
+            let errors = ServerlessConvention.checkIAMDeploymentRole(serverless.service);
             expect(errors.length).toBe(0);
         });
     });


### PR DESCRIPTION
Added a function to check for a valid deployment role.

cfnRole has been deprecated and replaced with deployment role. See: https://www.serverless.com/framework/docs/deprecations#grouping-iam-settings-under-provideriam

Closes #9 