### PR TITLE
Service name length validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export default class ServerlessConventions {
      // Service name validation
      // Must be kebab-case (dash delimited)
      // Must not contain the word "service"
+     // TODO: Must be less than x characters
      checkServiceName(service: Service) : Array<string> {
           let errors : Array<string> = [];
           const serviceName = service.getServiceName() as string;
@@ -85,6 +86,11 @@ export default class ServerlessConventions {
           // Check that the service name does not contain the word "service"
           if (serviceName.toLowerCase().includes('service')) {
                errors.push(`Warning: Service name should not include the word "service"`);
+          }
+
+          // Check the length of the service name is not greater than x
+          if (serviceName.length > 255) {
+               errors.push(`Warning: Service name must be less than 255 characters`);
           }
 
           return errors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,8 @@ export default class ServerlessConventions {
           }
 
           // Check the length of the service name is not greater than x
-          if (serviceName.length > 255) {
-               errors.push(`Warning: Service name must be less than 255 characters`);
+          if (serviceName.length > 23) {
+               errors.push(`Warning: Service name must be less than 23 characters`);
           }
 
           return errors;

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -131,6 +131,11 @@ describe('Test conventions plugin', () => {
             errors = ServerlessConvention.checkServiceName(serverless.service);
             expect(errors.pop()).toMatch('not include the word "service"');
             expect(errors.pop()).toMatch('is not kebab case');
+
+            // Both not kebab case and word "service" in the name
+            serverless.service.getServiceName = function () { return 'thisnameisverylongitshouldnotbethislongorelseitwontbeavalidnameidontknowwhatelsetowritehereas255charactersisalotofcharactersheressomerandomlygeneratedwordsedgecornerspacewhetherglasshorsemacaronichildrendictionarystickmultiplylookactstreetstraightbelleattaco' };
+            errors = ServerlessConvention.checkServiceName(serverless.service);
+            expect(errors.pop()).toMatch('name must be less than');
         });
 
         test('Correct service name', async () => {


### PR DESCRIPTION
Validate the max length of the service name.

23 is currently the max "safe" length for a service name due to S3 bucket naming.