### PR TITLE
Function names should not be overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A [Serverless framework](https://www.serverless.com) plugin to enforce various f
 | Service name must be less than 24 characters | this-is-a-good-name | this-is-a-bad-name-because-its-too-long |
 | Handler names must have the same name as the function | functions:<br>&nbsp;thisIsAWellNamedExample:<br>&nbsp;&nbsp;handler: src/this-is-a-well-named-example.handler | functions:<br>&nbsp;thisIsABadlyNamedFunction:<br>&nbsp;&nbsp;handler: src/this-is-a-badly-named-example.handler |
 | Function names must be in camel case | thisIsAWellNamedExample | ThisIsABadlyNamedExample |
+| Function names should not be overwritten | functions:<br>&nbsp;exampleFunction:<br>&nbsp;&nbsp;handler: src/example-function.handler | functions:<br>&nbsp;exampleFunction:<br>&nbsp;&nbsp;name: exampleFunction<br>&nbsp;&nbsp;handler: src/example-function.handler
 | Handler names must be dash delimited | src/this-is-a-well-named-example.handler | src/ThisIsABadlyNamedExample.handler |
 | Handler names must end in ".handler" | src/this-is-a-well-named-example.handler | src/this-is-a-badly-named-example |
 | DynamoDB table names must be in kebab case | example-name-good-table-name | BadTableName |

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,14 +150,21 @@ export default class ServerlessConventions {
 
      // Function name conventions
      // Must be camelCase
+     // Must use the default function name
      checkFunctionName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
           let errors: Array<string> = [];
           // Get the function name and strip the service name and stage from it
           const fnName = fn.name?.split(this.serverless.service.provider.stage + "-").pop() as string;
 
           // Check that the function name is in camel case
-          if (fnName !== camelCase(fnName)) {
+          if (fnName !== undefined && fnName !== camelCase(fnName)) {
                errors.push(`Warning: Function "${fnName}" is not camel case`);
+          }
+
+          // Check the name hasn't been overwritten with a custom name parameter
+          let expectedFnName = [this.serverless.service.getServiceName(), this.serverless.service.provider.stage, fnName].join("-");
+          if (fn.name !== expectedFnName) {
+               errors.push(`Warning: Function "${fnName}" is not using the default name. Remove the custom name property from the function.`);
           }
 
           return errors;

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -44,7 +44,7 @@ function createExampleServerless(): Serverless {
 
     // A good function and handler name
     let fn : Serverless.FunctionDefinitionHandler = {
-        name: 'thisIsAWellNamedFunction',
+        name: [serverless.service.getServiceName(), serverless.service.provider.stage, 'thisIsAWellNamedFunction'].join("-"),
         handler: "src/this-is-a-well-named-function.handler",
         events: []
     };
@@ -165,7 +165,7 @@ describe('Test conventions plugin', () => {
 
             // Handler does not match function name (this should be ignored so test should still pass)
             let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedFunction',
+                name: [ServerlessConvention.serverless.service.getServiceName(), ServerlessConvention.serverless.service.provider.stage, 'thisIsAWellNamedFunction'].join("-"),
                 handler: "src/this-is-a-badly-named-function.handler",
                 events: []
             };
@@ -276,7 +276,7 @@ describe('Test conventions plugin', () => {
             let ServerlessConvention = createServerlessConvention();
             // Kebab case
             let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'this-is-a-badly-named-example',
+                name: [ServerlessConvention.serverless.service.getServiceName(), ServerlessConvention.serverless.service.provider.stage, 'this-is-a-badly-named-example'].join("-"),
                 handler: "src/this-is-a-badly-named-example.handler",
                 events: []
             };
@@ -286,20 +286,24 @@ describe('Test conventions plugin', () => {
 
             // Capitalising first letter
             fn = {
-                name: 'ThisIsABadlyNamedFunction',
+                name: [ServerlessConvention.serverless.service.getServiceName(), ServerlessConvention.serverless.service.provider.stage, 'ThisIsABadlyNamedFunction'].join("-"),
                 handler: "this-is-a-badly-named-example.handler",
                 events: []
             };
 
             errors = ServerlessConvention.checkFunctionName(fn);
             expect(errors.pop()).toMatch('is not camel case');
+
+            // Check the name hasn't been overwritten with the name parameter
+
+
         });
 
         test('Correct function name', async () => {
             let ServerlessConvention = createServerlessConvention();
             // Function name should be in camel case
             let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedExample',
+                name: [ServerlessConvention.serverless.service.getServiceName(), ServerlessConvention.serverless.service.provider.stage, 'thisIsAWellNamedExample'].join("-"),
                 handler: "src/this-is-a-well-named-example.handler",
                 events: []
             };

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -294,9 +294,26 @@ describe('Test conventions plugin', () => {
             errors = ServerlessConvention.checkFunctionName(fn);
             expect(errors.pop()).toMatch('is not camel case');
 
-            // Check the name hasn't been overwritten with the name parameter
+            // Changing default name 
+            fn = {
+                name: 'thisIsAWellNamedExample',
+                handler: "this-is-a-badly-named-example.handler",
+                events: []
+            };
 
+            errors = ServerlessConvention.checkFunctionName(fn);
+            expect(errors.pop()).toMatch('is not using the default name');
 
+            // Changing default name and kebab case
+            fn = {
+                name: [ServerlessConvention.serverless.service.provider.stage, 'this-is-a-badly-named-example'].join("-"),
+                handler: "this-is-a-badly-named-example.handler",
+                events: []
+            };
+
+            errors = ServerlessConvention.checkFunctionName(fn);
+            expect(errors.pop()).toMatch('is not using the default name');
+            expect(errors.pop()).toMatch('is not camel case');
         });
 
         test('Correct function name', async () => {


### PR DESCRIPTION
By default, serverless automatically names functions by prepending the service name and stage to the function name. As an example: 
```
service: example-name

provider:
  stage: staging

functions:
  hello:
    handler: src/hello.handler
```
Is given the function name `example-name-staging-hello`

This behavior can be overwritten:
```
service: example-name

provider:
  stage: staging

functions:
  hello:
    name: ${self:service}-hello
    handler: src/hello.handler
```
Which would result in `example-name-hello`

Overriding the function name can cause issues when it comes to checking if the function name is in camel case.
`DO-1277`