### PR TITLE
Validate node versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,12 @@ export default class ServerlessConventions {
                }
           }
 
+          // If there is an esbuild config check that the node versions match
+          let esbuildConfig = this.serverless.service.custom.esbuild;
+          if (esbuildConfig) {
+               errors = errors.concat(this.checkNodeVersion(this.serverless.service.provider.runtime, esbuildConfig.target));
+          }
+
           // If there were errors detected, print out a list and throw an error
           if (errors.length !== 0) {
                errors.forEach(error => {
@@ -199,6 +205,25 @@ export default class ServerlessConventions {
           // Check that the function name is in snake case
           if (tableName !== kebabCase(tableName)) {
                errors.push(`Warning: DynamoDB table name "${tableName}" is not kebab case`);
+          }
+
+          return errors;
+     }
+
+     // Check the node version in esbuild config matches the one set as the provider runtime
+     checkNodeVersion(providerVersion: string, esBuildVersion: string): Array<string> {
+          let errors: Array<string> = [];
+
+          // providerVersion : nodejs14.x
+          // esBuildVersion  : node14
+          // Compare these two versions and make sure the numbers match
+          const versionNumberRegex = /\d+/i
+
+          const providerVersionNum =  providerVersion.match(versionNumberRegex).pop();
+          const esBuildVersionNum = providerVersion.match(versionNumberRegex).pop();
+
+          if (providerVersionNum !== esBuildVersionNum) {
+               errors.push(`Warning: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`);
           }
 
           return errors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export default class ServerlessConventions {
 
           // If there is an esbuild config check that the node versions match
           let esbuildConfig = this.serverless.service.custom.esbuild;
-          if (esbuildConfig) {
+          if (esbuildConfig && esbuildConfig.target) {
                errors = errors.concat(this.checkNodeVersion(this.serverless.service.provider.runtime, esbuildConfig.target));
           }
 
@@ -220,7 +220,7 @@ export default class ServerlessConventions {
           const versionNumberRegex = /\d+/i
 
           const providerVersionNum =  providerVersion.match(versionNumberRegex).pop();
-          const esBuildVersionNum = providerVersion.match(versionNumberRegex).pop();
+          const esBuildVersionNum = esBuildVersion.match(versionNumberRegex).pop();
 
           if (providerVersionNum !== esBuildVersionNum) {
                errors.push(`Warning: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`);

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -29,7 +29,11 @@ function createExampleServerless(): Serverless {
         stage: 'test',
         region: 'ap-southeast-2',
         versionFunctions: false,
+        runtime: 'nodejs14.x'
     } as any
+    serverless.service.custom.esbuild = {
+        target: 'node14'
+    }
 
     // Create some example resources
     const resource : CloudFormationResource = {
@@ -431,6 +435,22 @@ describe('Test conventions plugin', () => {
             }
 
             let errors = ServerlessConvention.checkDynamoDBTableName(resource, ServerlessConvention.serverless.service.getServiceName());
+            expect(errors.length).toBe(0);
+        });
+    });
+    
+    describe('Test node version', () => {
+        test('Different node versions', async () => {
+            let ServerlessConvention = createServerlessConvention();
+
+            let errors = ServerlessConvention.checkNodeVersion("nodejs14.x", "node12");
+            expect(errors.pop()).toMatch('does not match esbuild node version');
+        });
+
+        test('Same node version', async () => {
+            let ServerlessConvention = createServerlessConvention();
+
+            let errors = ServerlessConvention.checkNodeVersion("nodejs14.x", "node14");
             expect(errors.length).toBe(0);
         });
     });


### PR DESCRIPTION
When using esbuild it's important to use the same target as the provider runtime. If these values are different it can cause some cryptic errors.

This conventions check will display an error when these two values are set differently.

`DO-1276`