### PR TITLE
Restrict stages to three characters and alphabets only

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Ignore artifacts:
+.esbuild
+.localstack-volume
+.serverless

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+singleQuote: true
+semi: true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A [Serverless framework](https://www.serverless.com) plugin to enforce various f
 | Service name must be dash delimited | this-is-a-good-name | thisIsABadName |
 | Service name must not contain the word "service" | this-is-a-good-name | this-is-a-bad-service | 
 | Service name must be less than 24 characters | this-is-a-good-name | this-is-a-bad-name-because-its-too-long |
+| Stage must contains only lower case alphabet characters | dev | Development |
+| Stage must be exactly 3 characters long | prd | prod |
 | Handler names must have the same name as the function | functions:<br>&nbsp;thisIsAWellNamedExample:<br>&nbsp;&nbsp;handler: src/this-is-a-well-named-example.handler | functions:<br>&nbsp;thisIsABadlyNamedFunction:<br>&nbsp;&nbsp;handler: src/this-is-a-badly-named-example.handler |
 | Function names must be in camel case | thisIsAWellNamedExample | ThisIsABadlyNamedExample |
 | Handler names must be dash delimited | src/this-is-a-well-named-example.handler | src/ThisIsABadlyNamedExample.handler |
@@ -35,6 +37,7 @@ A list of all the available ignore commands are below:
 conventions:
   ignore:
     serviceName: true
+    stageName: true
     handlerName: true
     functionName: true
     handlerNameMatchesFunction: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,233 +1,298 @@
-import Serverless from "serverless";
-import { Options } from "serverless";
+import Serverless from 'serverless';
+import { Options } from 'serverless';
 import chalk from 'chalk';
-import { camelCase, paramCase as kebabCase } from "change-case";
-import Aws from "serverless/plugins/aws/provider/awsProvider";
-import Service from "serverless/classes/Service";
+import { camelCase, paramCase as kebabCase } from 'change-case';
+import Aws from 'serverless/plugins/aws/provider/awsProvider';
+import Service from 'serverless/classes/Service';
 
 type ConventionsConfig = {
-     ignore?: {
-          serviceName?: boolean,
-          handlerName?: boolean,
-          functionName?: boolean,
-          handlerNameMatchesFunction?: boolean,
-          dynamoDBTableName?: boolean,
-     }
-}
+  ignore?: {
+    serviceName?: boolean;
+    handlerName?: boolean;
+    functionName?: boolean;
+    handlerNameMatchesFunction?: boolean;
+    dynamoDBTableName?: boolean;
+  };
+};
 
 export default class ServerlessConventions {
-     serverless: Serverless;
-     hooks: { [key: string]: Function }
-     commands: any
-     config: any
-     options: Options
-     conventionsConfig: ConventionsConfig
+  serverless: Serverless;
+  hooks: { [key: string]: Function };
+  commands: any;
+  config: any;
+  options: Options;
+  conventionsConfig: ConventionsConfig;
 
-     constructor(serverless: Serverless, options: Options) {
-          this.serverless = serverless;
-          this.options = options;
-          this.config = '';
+  constructor(serverless: Serverless, options: Options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.config = '';
 
-          this.commands = {
-               'conventions-check': {
-                    usage: 'Runs the serverless conventions plugin',
-                    lifecycleEvents: ['run'],
-               },
-          };
+    this.commands = {
+      'conventions-check': {
+        usage: 'Runs the serverless conventions plugin',
+        lifecycleEvents: ['run'],
+      },
+    };
 
-          this.hooks = {
-               'before:package:compileFunctions': this.initialize.bind(this),
-               'conventions-check:run': () => this.initialize(),
-          };
+    this.hooks = {
+      'before:package:compileFunctions': this.initialize.bind(this),
+      'conventions-check:run': () => this.initialize(),
+    };
 
-          this.serverless.configSchemaHandler.defineTopLevelProperty('conventions', {
-               type: 'object',
-               properties: {
-                    ignore: { type: 'object' },
-               },
-          });
+    this.serverless.configSchemaHandler.defineTopLevelProperty('conventions', {
+      type: 'object',
+      properties: {
+        ignore: { type: 'object' },
+      },
+    });
 
-          this.conventionsConfig = this.serverless.service.initialServerlessConfig.conventions;
+    this.conventionsConfig =
+      this.serverless.service.initialServerlessConfig.conventions;
 
-          // Make sure ignore is defined to prevent errors being from being thrown when referencing children
-          if (this.conventionsConfig === undefined) {
-               this.conventionsConfig = {};
-          }
-          if (this.conventionsConfig.ignore === undefined) {
-               this.conventionsConfig.ignore = {};
-          }
-     }
+    // Make sure ignore is defined to prevent errors being from being thrown when referencing children
+    if (this.conventionsConfig === undefined) {
+      this.conventionsConfig = {};
+    }
+    if (this.conventionsConfig.ignore === undefined) {
+      this.conventionsConfig.ignore = {};
+    }
+  }
 
-     initialize() {
-          // Check that all the conventions are followed and build a list of errors
-          let errors: Array<string> = []
+  initialize() {
+    // Check that all the conventions are followed and build a list of errors
+    let errors: Array<string> = [];
 
-          errors = this.conventionsConfig.ignore.serviceName ? errors : errors.concat(this.checkServiceName(this.serverless.service));
+    errors = this.conventionsConfig.ignore.serviceName
+      ? errors
+      : errors.concat(this.checkServiceName(this.serverless.service));
 
-          const functionNames = this.serverless.service.getAllFunctions();
-          functionNames.forEach(fnName => {
-               const fn = this.serverless.service.getFunction(fnName) as Serverless.FunctionDefinitionHandler;
+    const functionNames = this.serverless.service.getAllFunctions();
+    functionNames.forEach((fnName) => {
+      const fn = this.serverless.service.getFunction(
+        fnName
+      ) as Serverless.FunctionDefinitionHandler;
 
-               errors = this.conventionsConfig.ignore.handlerName ? errors : errors.concat(this.checkHandlerName(fn));
-               errors = this.conventionsConfig.ignore.functionName ? errors : errors.concat(this.checkFunctionName(fn));
-               errors = this.conventionsConfig.ignore.handlerNameMatchesFunction ? errors : errors.concat(this.checkHandlerNameMatchesFunction(fn));
-          });
+      errors = this.conventionsConfig.ignore.handlerName
+        ? errors
+        : errors.concat(this.checkHandlerName(fn));
+      errors = this.conventionsConfig.ignore.functionName
+        ? errors
+        : errors.concat(this.checkFunctionName(fn));
+      errors = this.conventionsConfig.ignore.handlerNameMatchesFunction
+        ? errors
+        : errors.concat(this.checkHandlerNameMatchesFunction(fn));
+    });
 
-          // Loop through all the resources and run checks as required
-          const resources: Aws.CloudFormationResources = this.serverless.resources?.Resources;
-          for (const resourceKey in resources) {
-               const resource = resources[resourceKey];
+    // Loop through all the resources and run checks as required
+    const resources: Aws.CloudFormationResources =
+      this.serverless.resources?.Resources;
+    for (const resourceKey in resources) {
+      const resource = resources[resourceKey];
 
-               // Run different tests depending on the resource type
-               if (resource.Type === 'AWS::DynamoDB::Table') {
-                    errors = this.conventionsConfig.ignore.dynamoDBTableName ? errors : errors.concat(this.checkDynamoDBTableName(resource, this.serverless.service.getServiceName()));
-               }
-          }
+      // Run different tests depending on the resource type
+      if (resource.Type === 'AWS::DynamoDB::Table') {
+        errors = this.conventionsConfig.ignore.dynamoDBTableName
+          ? errors
+          : errors.concat(
+              this.checkDynamoDBTableName(
+                resource,
+                this.serverless.service.getServiceName()
+              )
+            );
+      }
+    }
 
-          // If there is an esbuild config check that the node versions match
-          let esbuildConfig = this.serverless.service.custom.esbuild;
-          if (esbuildConfig && esbuildConfig.target) {
-               errors = errors.concat(this.checkNodeVersion(this.serverless.service.provider.runtime, esbuildConfig.target));
-          }
+    // If there is an esbuild config check that the node versions match
+    let esbuildConfig = this.serverless.service.custom.esbuild;
+    if (esbuildConfig && esbuildConfig.target) {
+      errors = errors.concat(
+        this.checkNodeVersion(
+          this.serverless.service.provider.runtime,
+          esbuildConfig.target
+        )
+      );
+    }
 
-          // If there were errors detected, print out a list and throw an error
-          if (errors.length !== 0) {
-               errors.forEach(error => {
-                    this.serverless.cli.log(chalk.red(error));
-               });
+    // If there were errors detected, print out a list and throw an error
+    if (errors.length !== 0) {
+      errors.forEach((error) => {
+        this.serverless.cli.log(chalk.red(error));
+      });
 
-               throw Error('Serverless conventions validation failed');
-          }
+      throw Error('Serverless conventions validation failed');
+    }
 
-          this.serverless.cli.log(chalk.green('Conventions check complete! No errors were found.'));
-     }
+    this.serverless.cli.log(
+      chalk.green('Conventions check complete! No errors were found.')
+    );
+  }
 
-     // Service name validation
-     // Must be kebab-case (dash delimited)
-     // Must not contain the word "service"
-     // Must be less 23 or less characters
-     checkServiceName(service: Service): Array<string> {
-          let errors: Array<string> = [];
-          const serviceName = service.getServiceName() as string;
+  // Service name validation
+  // Must be kebab-case (dash delimited)
+  // Must not contain the word "service"
+  // Must be less 23 or less characters
+  checkServiceName(service: Service): Array<string> {
+    let errors: Array<string> = [];
+    const serviceName = service.getServiceName() as string;
 
-          // Check that the service name is in kebab case
-          if (serviceName !== kebabCase(serviceName)) {
-               errors.push(`Warning: Service name "${serviceName}" is not kebab case (dash delimited)`);
-          }
+    // Check that the service name is in kebab case
+    if (serviceName !== kebabCase(serviceName)) {
+      errors.push(
+        `Warning: Service name "${serviceName}" is not kebab case (dash delimited)`
+      );
+    }
 
-          // Check that the service name does not contain the word "service"
-          if (serviceName.toLowerCase().includes('service')) {
-               errors.push(`Warning: Service name should not include the word "service"`);
-          }
+    // Check that the service name does not contain the word "service"
+    if (serviceName.toLowerCase().includes('service')) {
+      errors.push(
+        `Warning: Service name should not include the word "service"`
+      );
+    }
 
-          // Check the length of the service name is not greater than x
-          if (serviceName.length > 23) {
-               errors.push(`Warning: Service name must be less than 23 characters`);
-          }
+    // Check the length of the service name is not greater than x
+    if (serviceName.length > 23) {
+      errors.push(`Warning: Service name must be less than 23 characters`);
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 
-     // Handler name conventions
-     // Must be kebab-case (dash delimited)
-     // Must end in .handler
-     checkHandlerName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
-          let errors: Array<string> = [];
+  // Handler name conventions
+  // Must be kebab-case (dash delimited)
+  // Must end in .handler
+  checkHandlerName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
+    let errors: Array<string> = [];
 
-          // Get the full handler name (including path)
-          const handlerFullPath = fn.handler as string;
-          // Get the handler name with file extension but no path
-          const handlerName = handlerFullPath.split('/').pop() as string;
-          // Get the handler name with no path and no file extension
-          const handlerNameNoExtension = handlerName.replace('.handler', '') as string;
+    // Get the full handler name (including path)
+    const handlerFullPath = fn.handler as string;
+    // Get the handler name with file extension but no path
+    const handlerName = handlerFullPath.split('/').pop() as string;
+    // Get the handler name with no path and no file extension
+    const handlerNameNoExtension = handlerName.replace(
+      '.handler',
+      ''
+    ) as string;
 
-          // Check that the handler name is in kebab case
-          if (handlerNameNoExtension !== kebabCase(handlerNameNoExtension)) {
-               errors.push(`Warning: Handler "${handlerName}" is not kebab case (dash delimited)`);
-          }
+    // Check that the handler name is in kebab case
+    if (handlerNameNoExtension !== kebabCase(handlerNameNoExtension)) {
+      errors.push(
+        `Warning: Handler "${handlerName}" is not kebab case (dash delimited)`
+      );
+    }
 
-          // Check that the handler ends in .handler
-          if (handlerNameNoExtension === handlerName) {
-               errors.push(`Warning: Handler "${handlerName}" does not end in ".handler"`);
-          }
+    // Check that the handler ends in .handler
+    if (handlerNameNoExtension === handlerName) {
+      errors.push(
+        `Warning: Handler "${handlerName}" does not end in ".handler"`
+      );
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 
-     // Function name conventions
-     // Must be camelCase
-     checkFunctionName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
-          let errors: Array<string> = [];
-          // Get the function name and strip the service name and stage from it
-          const fnName = fn.name?.split(this.serverless.service.provider.stage + "-").pop() as string;
+  // Function name conventions
+  // Must be camelCase
+  checkFunctionName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
+    let errors: Array<string> = [];
+    // Get the function name and strip the service name and stage from it
+    const fnName = fn.name
+      ?.split(this.serverless.service.provider.stage + '-')
+      .pop() as string;
 
-          // Check that the function name is in camel case
-          if (fnName !== camelCase(fnName)) {
-               errors.push(`Warning: Function "${fnName}" is not camel case`);
-          }
+    // Check that the function name is in camel case
+    if (fnName !== camelCase(fnName)) {
+      errors.push(`Warning: Function "${fnName}" is not camel case`);
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 
-     // Function / handler name conventions
-     // Handler names must have the same name as the function
-     checkHandlerNameMatchesFunction(fn: Serverless.FunctionDefinitionHandler): Array<string> {
-          let errors: Array<string> = [];
-          // Get the function name and strip the service name and stage from it
-          const fnName = fn.name?.split(this.serverless.service.provider.stage + "-").pop() as string;
+  // Function / handler name conventions
+  // Handler names must have the same name as the function
+  checkHandlerNameMatchesFunction(
+    fn: Serverless.FunctionDefinitionHandler
+  ): Array<string> {
+    let errors: Array<string> = [];
+    // Get the function name and strip the service name and stage from it
+    const fnName = fn.name
+      ?.split(this.serverless.service.provider.stage + '-')
+      .pop() as string;
 
-          // Get handler name removing any path and the .handler extension
-          const handler = fn.handler.split('/').pop()?.replace('.handler', '') as string;
+    // Get handler name removing any path and the .handler extension
+    const handler = fn.handler
+      .split('/')
+      .pop()
+      ?.replace('.handler', '') as string;
 
-          // Create an error if the function does not match the handler name
-          if (camelCase(fnName) !== camelCase(handler) && kebabCase(fnName) !== kebabCase(handler)) {
-               errors.push(`Warning: Function "${fnName}" does not match handler name "${handler}.handler"`);
-          }
+    // Create an error if the function does not match the handler name
+    if (
+      camelCase(fnName) !== camelCase(handler) &&
+      kebabCase(fnName) !== kebabCase(handler)
+    ) {
+      errors.push(
+        `Warning: Function "${fnName}" does not match handler name "${handler}.handler"`
+      );
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 
-     // DynamoDB table name validation
-     // DynamoDB table names should be in snake case
-     checkDynamoDBTableName(dynamodb: Aws.CloudFormationResource, serviceName: string): Array<string> {
-          let errors: Array<string> = [];
+  // DynamoDB table name validation
+  // DynamoDB table names should be in snake case
+  checkDynamoDBTableName(
+    dynamodb: Aws.CloudFormationResource,
+    serviceName: string
+  ): Array<string> {
+    let errors: Array<string> = [];
 
-          // Get the table name
-          const tableName = dynamodb.Properties['tableName'] as string;
+    // Get the table name
+    const tableName = dynamodb.Properties['tableName'] as string;
 
-          // Check it starts with the service name
-          const tableNameWithoutService = tableName.split(serviceName + '-').pop() as string;
+    // Check it starts with the service name
+    const tableNameWithoutService = tableName
+      .split(serviceName + '-')
+      .pop() as string;
 
-          if (tableName == tableNameWithoutService) {
-               errors.push(`Warning: DynamoDB table name "${tableName}" does not start with the service name`);
-          }
+    if (tableName == tableNameWithoutService) {
+      errors.push(
+        `Warning: DynamoDB table name "${tableName}" does not start with the service name`
+      );
+    }
 
-          // Check that the function name is in snake case
-          if (tableName !== kebabCase(tableName)) {
-               errors.push(`Warning: DynamoDB table name "${tableName}" is not kebab case`);
-          }
+    // Check that the function name is in snake case
+    if (tableName !== kebabCase(tableName)) {
+      errors.push(
+        `Warning: DynamoDB table name "${tableName}" is not kebab case`
+      );
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 
-     // Check the node version in esbuild config matches the one set as the provider runtime
-     checkNodeVersion(providerVersion: string, esBuildVersion: string): Array<string> {
-          let errors: Array<string> = [];
+  // Check the node version in esbuild config matches the one set as the provider runtime
+  checkNodeVersion(
+    providerVersion: string,
+    esBuildVersion: string
+  ): Array<string> {
+    let errors: Array<string> = [];
 
-          // providerVersion : nodejs14.x
-          // esBuildVersion  : node14
-          // Compare these two versions and make sure the numbers match
-          const versionNumberRegex = /\d+/i
+    // providerVersion : nodejs14.x
+    // esBuildVersion  : node14
+    // Compare these two versions and make sure the numbers match
+    const versionNumberRegex = /\d+/i;
 
-          const providerVersionNum =  providerVersion.match(versionNumberRegex).pop();
-          const esBuildVersionNum = esBuildVersion.match(versionNumberRegex).pop();
+    const providerVersionNum = providerVersion.match(versionNumberRegex).pop();
+    const esBuildVersionNum = esBuildVersion.match(versionNumberRegex).pop();
 
-          if (providerVersionNum !== esBuildVersionNum) {
-               errors.push(`Warning: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`);
-          }
+    if (providerVersionNum !== esBuildVersionNum) {
+      errors.push(
+        `Warning: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`
+      );
+    }
 
-          return errors;
-     }
+    return errors;
+  }
 }
 
 module.exports = ServerlessConventions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import Aws from 'serverless/plugins/aws/provider/awsProvider';
 import Service from 'serverless/classes/Service';
 
 type ConventionsConfig = {
-  ignore: {
+  ignore?: {
     serviceName?: boolean;
     stageName?: boolean;
     handlerName?: boolean;
@@ -53,9 +53,10 @@ export default class ServerlessConventions {
 
     // Make sure ignore is defined to prevent errors being from being thrown when referencing children
     if (this.conventionsConfig === undefined) {
-      this.conventionsConfig = {
-        ignore: {},
-      };
+      this.conventionsConfig = {};
+    }
+    if (this.conventionsConfig.ignore === undefined) {
+      this.conventionsConfig.ignore = {};
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Service from 'serverless/classes/Service';
 type ConventionsConfig = {
   ignore: {
     serviceName?: boolean;
+    stageName?: boolean;
     handlerName?: boolean;
     functionName?: boolean;
     handlerNameMatchesFunction?: boolean;
@@ -65,6 +66,10 @@ export default class ServerlessConventions {
     errors = this.conventionsConfig.ignore.serviceName
       ? errors
       : errors.concat(this.checkServiceName(this.serverless.service));
+
+    errors = this.conventionsConfig.ignore.stageName
+      ? errors
+      : errors.concat(this.checkStageName(this.serverless.service));
 
     const functionNames = this.serverless.service.getAllFunctions();
     functionNames.forEach((fnName) => {
@@ -145,13 +150,39 @@ export default class ServerlessConventions {
     // Check that the service name does not contain the word "service"
     if (serviceName.toLowerCase().includes('service')) {
       errors.push(
-        `Warning: Service name should not include the word "service"`
+        `Warning: Service name "${serviceName}" should not include the word "service"`
       );
     }
 
     // Check the length of the service name is not greater than x
     if (serviceName.length > 23) {
-      errors.push(`Warning: Service name must be less than 23 characters`);
+      errors.push(
+        `Warning: Service name "${serviceName}" must be less than 23 characters`
+      );
+    }
+
+    return errors;
+  }
+
+  // Stage name validation
+  // Must contains only lower case alphabet characters
+  // Must be only 3 characters
+  checkStageName(service: Service): Array<string> {
+    let errors: Array<string> = [];
+    const stageName = service.provider.stage;
+
+    // Check that the stage name contains only lower case alphabet characters (a-z)
+    if (stageName.match(/[^a-z]/)) {
+      errors.push(
+        `Warning: Stage name "${stageName}" should contains only alphabet characters in lower case`
+      );
+    }
+
+    // Check the length of the stage name is 3 characters
+    if (stageName.length !== 3) {
+      errors.push(
+        `Warning: Stage name "${stageName}" must be 3 characters long`
+      );
     }
 
     return errors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import Aws from 'serverless/plugins/aws/provider/awsProvider';
 import Service from 'serverless/classes/Service';
 
 type ConventionsConfig = {
-  ignore?: {
+  ignore: {
     serviceName?: boolean;
     handlerName?: boolean;
     functionName?: boolean;
@@ -52,10 +52,9 @@ export default class ServerlessConventions {
 
     // Make sure ignore is defined to prevent errors being from being thrown when referencing children
     if (this.conventionsConfig === undefined) {
-      this.conventionsConfig = {};
-    }
-    if (this.conventionsConfig.ignore === undefined) {
-      this.conventionsConfig.ignore = {};
+      this.conventionsConfig = {
+        ignore: {},
+      };
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ export default class ServerlessConventions {
   }
 
   // Stage name validation
-  // Must contains only lower case alphabet characters
+  // Must contain only lower case alphabet characters
   // Must be only 3 characters
   checkStageName(service: Service): Array<string> {
     let errors: Array<string> = [];
@@ -174,7 +174,7 @@ export default class ServerlessConventions {
     // Check that the stage name contains only lower case alphabet characters (a-z)
     if (stageName.match(/[^a-z]/)) {
       errors.push(
-        `Warning: Stage name "${stageName}" should contains only alphabet characters in lower case`
+        `Warning: Stage name "${stageName}" should only contain alphabet characters in lower case`
       );
     }
 

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -1,457 +1,513 @@
-import ServerlessConventions from "../src/index";
-import Serverless from "serverless";
-import { CloudFormationResource } from "serverless/plugins/aws/provider/awsProvider";
+import ServerlessConventions from '../src/index';
+import Serverless from 'serverless';
+import { CloudFormationResource } from 'serverless/plugins/aws/provider/awsProvider';
 
 function createExampleServerless(): Serverless {
-    const options : Serverless.Options = {
-        stage: 'test',
-        region: 'ap-southeast-2',
-    };
+  const options: Serverless.Options = {
+    stage: 'test',
+    region: 'ap-southeast-2',
+  };
 
-    // Log any cli events to jest
-    const cli = {
-        log: jest.fn(),
-    }
+  // Log any cli events to jest
+  const cli = {
+    log: jest.fn(),
+  };
 
-    let serverless : Serverless = new Serverless({options});
+  let serverless: Serverless = new Serverless({ options });
 
-    serverless.cli = cli;
-    serverless.service.provider.stage = 'test';
-    serverless.service.initialServerlessConfig = {};
-    // Return a service name
-    serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
-    // Set some basic provider information
-    serverless.service.provider = {
-        compiledCloudFormationTemplate: {
-            Resources: {}
-        },
-        name: 'aws',
-        stage: 'test',
-        region: 'ap-southeast-2',
-        versionFunctions: false,
-        runtime: 'nodejs14.x'
-    } as any
-    serverless.service.custom.esbuild = {
-        target: 'node14'
-    }
+  serverless.cli = cli;
+  serverless.service.provider.stage = 'test';
+  serverless.service.initialServerlessConfig = {};
+  // Return a service name
+  serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
+  // Set some basic provider information
+  serverless.service.provider = {
+    compiledCloudFormationTemplate: {
+      Resources: {},
+    },
+    name: 'aws',
+    stage: 'test',
+    region: 'ap-southeast-2',
+    versionFunctions: false,
+    runtime: 'nodejs14.x',
+  } as any;
+  serverless.service.custom.esbuild = {
+    target: 'node14',
+  };
 
-    // Create some example resources
-    const resource : CloudFormationResource = {
-        Type: 'AWS::DynamoDB::Table',
-        Properties: {
-            'tableName': 'test-name-good-table-name'
-        }
-    }
-    serverless.resources = {
-        Resources: {'db': resource}
-    }
+  // Create some example resources
+  const resource: CloudFormationResource = {
+    Type: 'AWS::DynamoDB::Table',
+    Properties: {
+      tableName: 'test-name-good-table-name',
+    },
+  };
+  serverless.resources = {
+    Resources: { db: resource },
+  };
 
-    // A good function and handler name
-    let fn : Serverless.FunctionDefinitionHandler = {
-        name: 'thisIsAWellNamedFunction',
-        handler: "src/this-is-a-well-named-function.handler",
-        events: []
-    };
+  // A good function and handler name
+  let fn: Serverless.FunctionDefinitionHandler = {
+    name: 'thisIsAWellNamedFunction',
+    handler: 'src/this-is-a-well-named-function.handler',
+    events: [],
+  };
 
-    serverless.service.getAllFunctions = jest.fn().mockReturnValue(['thisIsAWellNamedFunction']);
-    serverless.service.getFunction = jest.fn().mockReturnValue(fn);
+  serverless.service.getAllFunctions = jest
+    .fn()
+    .mockReturnValue(['thisIsAWellNamedFunction']);
+  serverless.service.getFunction = jest.fn().mockReturnValue(fn);
 
-    return serverless;
+  return serverless;
 }
 
 function createServerlessConvention(): ServerlessConventions {
-    // Create a valid serverless instance
-    const serverless : Serverless = createExampleServerless();
-    const options : Serverless.Options = {
-        stage: 'test',
-        region: 'ap-southeast-2',
-    };
+  // Create a valid serverless instance
+  const serverless: Serverless = createExampleServerless();
+  const options: Serverless.Options = {
+    stage: 'test',
+    region: 'ap-southeast-2',
+  };
 
-    // Create a serverless conventions instance
-    const ServerlessConvention: ServerlessConventions = new ServerlessConventions(
-        serverless, options
-    );
+  // Create a serverless conventions instance
+  const ServerlessConvention: ServerlessConventions = new ServerlessConventions(
+    serverless,
+    options
+  );
 
-    return ServerlessConvention;
+  return ServerlessConvention;
 }
 
 describe('Test conventions plugin', () => {
-    describe('Integration test', () => {
-        test('Initialize function valid serverless.yml', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Run the initialize function
-            expect(() => {
-                ServerlessConvention.initialize()
-            }).not.toThrowError();
-        });
-
-        test('Initialize function valid serverless.yml without resources', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Remove all resources from serverless
-            ServerlessConvention.serverless.resources = {Resources: {}}
-
-            // Run the initialize function
-            expect(() => {
-                ServerlessConvention.initialize()
-            }).not.toThrowError();
-        });
-
-        test('Initialize function invalid serverless.yml', async () => {
-            let serverless = createExampleServerless();
-            // Invalid service name
-            serverless.service.getServiceName = jest.fn().mockReturnValue('test-service');
-
-            // Bad function and handler name
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'ThisIsABadlyNamedFunction',
-                handler: "src/this-is-a-badly-named-example",
-                events: []
-            };
-
-            // Bad database name
-            const resource : CloudFormationResource = {
-                Type: 'AWS::DynamoDB::Table',
-                Properties: {
-                    'tableName': 'BadTableName'
-                }
-            }
-
-            serverless.resources = {
-                Resources: {'db': resource}
-            }
-
-            serverless.service.getAllFunctions = jest.fn().mockReturnValue(['ThisIsABadlyNamedFunction']);
-            serverless.service.getFunction = jest.fn().mockReturnValue(fn);
-
-            // Create another serverless instance with bad data
-            const BadServerlessConvention: ServerlessConventions = new ServerlessConventions(
-                serverless, { stage: 'test', region: 'ap-southeast-2' }
-            );
-
-            // Run the initialize function
-            expect(() => {
-                BadServerlessConvention.initialize()
-            }).toThrowError();
-        });
-
-        test('Initialize function with all ignore fields set to true', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            ServerlessConvention.conventionsConfig = {
-                ignore: {
-                    serviceName: true,
-                    handlerName: true,
-                    functionName: true,
-                    handlerNameMatchesFunction: true,
-                    dynamoDBTableName: true,
-                }
-            }
-
-            expect(() => {
-                ServerlessConvention.initialize()
-            }).not.toThrowError();
-        });
-
-        test('Initialize function with no ignore fields', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            ServerlessConvention.conventionsConfig = {
-                ignore: {}
-            }
-
-            expect(() => {
-                ServerlessConvention.initialize()
-            }).not.toThrowError();
-        });
-
-        test('Initialize function ignore service name check', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Ignore the service name check
-            ServerlessConvention.conventionsConfig.ignore.handlerNameMatchesFunction = true;
-
-            // Handler does not match function name (this should be ignored so test should still pass)
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedFunction',
-                handler: "src/this-is-a-badly-named-function.handler",
-                events: []
-            };
-
-            ServerlessConvention.serverless.service.getAllFunctions = jest.fn().mockReturnValue(['thisIsAWellNamedFunction']);
-            ServerlessConvention.serverless.service.getFunction = jest.fn().mockReturnValue(fn);
-
-            expect(() => {
-                ServerlessConvention.initialize()
-            }).not.toThrowError();
-        });
+  describe('Integration test', () => {
+    test('Initialize function valid serverless.yml', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Run the initialize function
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
     });
 
-    describe('Test service name checker', () => {
-        test('Incorrect service name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Not kebab case
-            ServerlessConvention.serverless.service.getServiceName = function () { return 'testName' };
-            let errors = ServerlessConvention.checkServiceName(ServerlessConvention.serverless.service);
-            expect(errors.pop()).toMatch('is not kebab case');
+    test('Initialize function valid serverless.yml without resources', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Remove all resources from serverless
+      ServerlessConvention.serverless.resources = { Resources: {} };
 
-            // No word "service" in the name
-            ServerlessConvention.serverless.service.getServiceName = function () { return 'test-service' };
-            errors = ServerlessConvention.checkServiceName(ServerlessConvention.serverless.service);
-            expect(errors.pop()).toMatch('not include the word "service"');
-
-            // Both not kebab case and word "service" in the name
-            ServerlessConvention.serverless.service.getServiceName = function () { return 'testService' };
-            errors = ServerlessConvention.checkServiceName(ServerlessConvention.serverless.service);
-            expect(errors.pop()).toMatch('not include the word "service"');
-            expect(errors.pop()).toMatch('is not kebab case');
-
-            // Both not kebab case and word "service" in the name
-            ServerlessConvention.serverless.service.getServiceName = function () { return 'thisnameisverylongitshouldnotbethislongorelseitwontbeavalidname' };
-            errors = ServerlessConvention.checkServiceName(ServerlessConvention.serverless.service);
-            expect(errors.pop()).toMatch('name must be less than');
-        });
-
-        test('Correct service name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Valid service name
-            ServerlessConvention.serverless.service.getServiceName = function () { return 'test-name' };
-            let errors = ServerlessConvention.checkServiceName(ServerlessConvention.serverless.service);
-            expect(errors.length).toBe(0);
-        });
+      // Run the initialize function
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
     });
 
-    describe('Test handler name checker', () => {
-        test('Incorrect handler name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Not kebab case
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsABadlyNamedExample',
-                handler: "src/This-is-a-badly-named-example.handler",
-                events: []
-            };
+    test('Initialize function invalid serverless.yml', async () => {
+      let serverless = createExampleServerless();
+      // Invalid service name
+      serverless.service.getServiceName = jest
+        .fn()
+        .mockReturnValue('test-service');
 
-            let errors = ServerlessConvention.checkHandlerName(fn);
-            expect(errors.pop()).toMatch('is not kebab case');
+      // Bad function and handler name
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'ThisIsABadlyNamedFunction',
+        handler: 'src/this-is-a-badly-named-example',
+        events: [],
+      };
 
-            fn = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "src/thisIsABadlyNamedExample.handler",
-                events: []
-            };
+      // Bad database name
+      const resource: CloudFormationResource = {
+        Type: 'AWS::DynamoDB::Table',
+        Properties: {
+          tableName: 'BadTableName',
+        },
+      };
 
-            errors = ServerlessConvention.checkHandlerName(fn);
-            expect(errors.pop()).toMatch('is not kebab case');
+      serverless.resources = {
+        Resources: { db: resource },
+      };
 
-            // No ".handler" extension
-            fn = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "this-is-a-badly-named-example",
-                events: []
-            };
+      serverless.service.getAllFunctions = jest
+        .fn()
+        .mockReturnValue(['ThisIsABadlyNamedFunction']);
+      serverless.service.getFunction = jest.fn().mockReturnValue(fn);
 
-            errors = ServerlessConvention.checkHandlerName(fn);
-            expect(errors.pop()).toMatch('does not end in ".handler"');
-
-            // No ".handler" extension and not kebab case
-            fn = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "This-is-a-badly-named-example",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkHandlerName(fn);
-            expect(errors.pop()).toMatch('does not end in ".handler"');
-            expect(errors.pop()).toMatch('is not kebab case');
+      // Create another serverless instance with bad data
+      const BadServerlessConvention: ServerlessConventions =
+        new ServerlessConventions(serverless, {
+          stage: 'test',
+          region: 'ap-southeast-2',
         });
 
-        test('Correct handler name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Handler name should be in kebab case with .handler extension
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedExample',
-                handler: "src/this-is-a-well-named-example.handler",
-                events: []
-            };
-
-            let errors = ServerlessConvention.checkHandlerName(fn);
-            expect(errors.length).toBe(0);
-        });
+      // Run the initialize function
+      expect(() => {
+        BadServerlessConvention.initialize();
+      }).toThrowError();
     });
 
-    describe('Test function name checker', () => {
-        test('Incorrect function name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Kebab case
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'this-is-a-badly-named-example',
-                handler: "src/this-is-a-badly-named-example.handler",
-                events: []
-            };
+    test('Initialize function with all ignore fields set to true', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      ServerlessConvention.conventionsConfig = {
+        ignore: {
+          serviceName: true,
+          handlerName: true,
+          functionName: true,
+          handlerNameMatchesFunction: true,
+          dynamoDBTableName: true,
+        },
+      };
 
-            let errors = ServerlessConvention.checkFunctionName(fn);
-            expect(errors.pop()).toMatch('is not camel case');
-
-            // Capitalising first letter
-            fn = {
-                name: 'ThisIsABadlyNamedFunction',
-                handler: "this-is-a-badly-named-example.handler",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkFunctionName(fn);
-            expect(errors.pop()).toMatch('is not camel case');
-        });
-
-        test('Correct function name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // Function name should be in camel case
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedExample',
-                handler: "src/this-is-a-well-named-example.handler",
-                events: []
-            };
-
-            let errors = ServerlessConvention.checkFunctionName(fn);
-            expect(errors.length).toBe(0);
-        });
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
     });
 
-    describe('Test handler name matches function check', () => {
-        test('Incorrect handler and function name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // With path and .handler
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "src/this-is-a-badly-named-example.handler",
-                events: []
-            };
+    test('Initialize function with no ignore fields', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      ServerlessConvention.conventionsConfig = {
+        ignore: {},
+      };
 
-            let errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.pop()).toMatch('does not match handler name');
-
-            // Without path but with handler
-            fn = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "this-is-a-badly-named-example.handler",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.pop()).toMatch('does not match handler name');
-
-            // Without path and handler
-            fn = {
-                name: 'thisIsABadlyNamedFunction',
-                handler: "this-is-a-badly-named-example",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.pop()).toMatch('does not match handler name');
-        });
-
-        test('Correct handler and function name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            // With path and .handler
-            let fn : Serverless.FunctionDefinitionHandler = {
-                name: 'thisIsAWellNamedExample',
-                handler: "src/this-is-a-well-named-example.handler",
-                events: []
-            };
-
-            let errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.length).toBe(0);
-
-            // Without path but with handler
-            fn = {
-                name: 'thisIsAWellNamedExample',
-                handler: "this-is-a-well-named-example.handler",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.length).toBe(0);
-
-            // Without path and handler
-            // Note that although a handler extension is required to be valid
-            // this function does not check that and therefore should return no errors
-            fn = {
-                name: 'thisIsAWellNamedExample',
-                handler: "this-is-a-well-named-example",
-                events: []
-            };
-
-            errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
-            expect(errors.length).toBe(0);
-        });
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
     });
 
-    describe('Test DynamoDB table name checker', () => {
-        test('Incorrect table name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            ServerlessConvention.serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
-            // DynamoDB table name should be in snake case
-            let resource : CloudFormationResource = {
-                Type: 'AWS::DynamoDB::Table',
-                Properties: {
-                    'tableName': 'test-name-bad_table_name'
-                }
-            }
+    test('Initialize function ignore service name check', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Ignore the service name check
+      ServerlessConvention.conventionsConfig.ignore.handlerNameMatchesFunction =
+        true;
 
-            let errors = ServerlessConvention.checkDynamoDBTableName(resource, ServerlessConvention.serverless.service.getServiceName());
-            expect(errors.pop()).toMatch('is not kebab case');
+      // Handler does not match function name (this should be ignored so test should still pass)
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsAWellNamedFunction',
+        handler: 'src/this-is-a-badly-named-function.handler',
+        events: [],
+      };
 
-            // DynamoDB table name should be in snake case and start with the service name
-            resource = {
-                Type: 'AWS::DynamoDB::Table',
-                Properties: {
-                    'tableName': 'Bad_table_name'
-                }
-            }
+      ServerlessConvention.serverless.service.getAllFunctions = jest
+        .fn()
+        .mockReturnValue(['thisIsAWellNamedFunction']);
+      ServerlessConvention.serverless.service.getFunction = jest
+        .fn()
+        .mockReturnValue(fn);
 
-            errors = ServerlessConvention.checkDynamoDBTableName(resource, ServerlessConvention.serverless.service.getServiceName());
-            expect(errors.pop()).toMatch('is not kebab case');
-            expect(errors.pop()).toMatch('does not start with the service name');
-
-            // DynamoDB table name should start with the service name
-            resource = {
-                Type: 'AWS::DynamoDB::Table',
-                Properties: {
-                    'tableName': 'bad-table-name'
-                }
-            }
-
-            errors = ServerlessConvention.checkDynamoDBTableName(resource, ServerlessConvention.serverless.service.getServiceName());
-            expect(errors.pop()).toMatch('does not start with the service name');
-        });
-
-        test('Correct table name', async () => {
-            let ServerlessConvention = createServerlessConvention();
-            ServerlessConvention.serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
-
-            // DynamoDB table name should be in snake case
-            const resource : CloudFormationResource = {
-                Type: 'AWS::DynamoDB::Table',
-                Properties: {
-                    'tableName': 'test-name-good-table-name'
-                }
-            }
-
-            let errors = ServerlessConvention.checkDynamoDBTableName(resource, ServerlessConvention.serverless.service.getServiceName());
-            expect(errors.length).toBe(0);
-        });
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
     });
-    
-    describe('Test node version', () => {
-        test('Different node versions', async () => {
-            let ServerlessConvention = createServerlessConvention();
+  });
 
-            let errors = ServerlessConvention.checkNodeVersion("nodejs14.x", "node12");
-            expect(errors.pop()).toMatch('does not match esbuild node version');
-        });
+  describe('Test service name checker', () => {
+    test('Incorrect service name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Not kebab case
+      ServerlessConvention.serverless.service.getServiceName = function () {
+        return 'testName';
+      };
+      let errors = ServerlessConvention.checkServiceName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('is not kebab case');
 
-        test('Same node version', async () => {
-            let ServerlessConvention = createServerlessConvention();
+      // No word "service" in the name
+      ServerlessConvention.serverless.service.getServiceName = function () {
+        return 'test-service';
+      };
+      errors = ServerlessConvention.checkServiceName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('not include the word "service"');
 
-            let errors = ServerlessConvention.checkNodeVersion("nodejs14.x", "node14");
-            expect(errors.length).toBe(0);
-        });
+      // Both not kebab case and word "service" in the name
+      ServerlessConvention.serverless.service.getServiceName = function () {
+        return 'testService';
+      };
+      errors = ServerlessConvention.checkServiceName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('not include the word "service"');
+      expect(errors.pop()).toMatch('is not kebab case');
+
+      // Both not kebab case and word "service" in the name
+      ServerlessConvention.serverless.service.getServiceName = function () {
+        return 'thisnameisverylongitshouldnotbethislongorelseitwontbeavalidname';
+      };
+      errors = ServerlessConvention.checkServiceName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('name must be less than');
     });
+
+    test('Correct service name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Valid service name
+      ServerlessConvention.serverless.service.getServiceName = function () {
+        return 'test-name';
+      };
+      let errors = ServerlessConvention.checkServiceName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test handler name checker', () => {
+    test('Incorrect handler name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Not kebab case
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsABadlyNamedExample',
+        handler: 'src/This-is-a-badly-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkHandlerName(fn);
+      expect(errors.pop()).toMatch('is not kebab case');
+
+      fn = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'src/thisIsABadlyNamedExample.handler',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerName(fn);
+      expect(errors.pop()).toMatch('is not kebab case');
+
+      // No ".handler" extension
+      fn = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'this-is-a-badly-named-example',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerName(fn);
+      expect(errors.pop()).toMatch('does not end in ".handler"');
+
+      // No ".handler" extension and not kebab case
+      fn = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'This-is-a-badly-named-example',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerName(fn);
+      expect(errors.pop()).toMatch('does not end in ".handler"');
+      expect(errors.pop()).toMatch('is not kebab case');
+    });
+
+    test('Correct handler name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Handler name should be in kebab case with .handler extension
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsAWellNamedExample',
+        handler: 'src/this-is-a-well-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkHandlerName(fn);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test function name checker', () => {
+    test('Incorrect function name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Kebab case
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'this-is-a-badly-named-example',
+        handler: 'src/this-is-a-badly-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkFunctionName(fn);
+      expect(errors.pop()).toMatch('is not camel case');
+
+      // Capitalising first letter
+      fn = {
+        name: 'ThisIsABadlyNamedFunction',
+        handler: 'this-is-a-badly-named-example.handler',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkFunctionName(fn);
+      expect(errors.pop()).toMatch('is not camel case');
+    });
+
+    test('Correct function name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // Function name should be in camel case
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsAWellNamedExample',
+        handler: 'src/this-is-a-well-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkFunctionName(fn);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test handler name matches function check', () => {
+    test('Incorrect handler and function name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // With path and .handler
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'src/this-is-a-badly-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.pop()).toMatch('does not match handler name');
+
+      // Without path but with handler
+      fn = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'this-is-a-badly-named-example.handler',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.pop()).toMatch('does not match handler name');
+
+      // Without path and handler
+      fn = {
+        name: 'thisIsABadlyNamedFunction',
+        handler: 'this-is-a-badly-named-example',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.pop()).toMatch('does not match handler name');
+    });
+
+    test('Correct handler and function name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      // With path and .handler
+      let fn: Serverless.FunctionDefinitionHandler = {
+        name: 'thisIsAWellNamedExample',
+        handler: 'src/this-is-a-well-named-example.handler',
+        events: [],
+      };
+
+      let errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.length).toBe(0);
+
+      // Without path but with handler
+      fn = {
+        name: 'thisIsAWellNamedExample',
+        handler: 'this-is-a-well-named-example.handler',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.length).toBe(0);
+
+      // Without path and handler
+      // Note that although a handler extension is required to be valid
+      // this function does not check that and therefore should return no errors
+      fn = {
+        name: 'thisIsAWellNamedExample',
+        handler: 'this-is-a-well-named-example',
+        events: [],
+      };
+
+      errors = ServerlessConvention.checkHandlerNameMatchesFunction(fn);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test DynamoDB table name checker', () => {
+    test('Incorrect table name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      ServerlessConvention.serverless.service.getServiceName = jest
+        .fn()
+        .mockReturnValue('test-name');
+      // DynamoDB table name should be in snake case
+      let resource: CloudFormationResource = {
+        Type: 'AWS::DynamoDB::Table',
+        Properties: {
+          tableName: 'test-name-bad_table_name',
+        },
+      };
+
+      let errors = ServerlessConvention.checkDynamoDBTableName(
+        resource,
+        ServerlessConvention.serverless.service.getServiceName()
+      );
+      expect(errors.pop()).toMatch('is not kebab case');
+
+      // DynamoDB table name should be in snake case and start with the service name
+      resource = {
+        Type: 'AWS::DynamoDB::Table',
+        Properties: {
+          tableName: 'Bad_table_name',
+        },
+      };
+
+      errors = ServerlessConvention.checkDynamoDBTableName(
+        resource,
+        ServerlessConvention.serverless.service.getServiceName()
+      );
+      expect(errors.pop()).toMatch('is not kebab case');
+      expect(errors.pop()).toMatch('does not start with the service name');
+
+      // DynamoDB table name should start with the service name
+      resource = {
+        Type: 'AWS::DynamoDB::Table',
+        Properties: {
+          tableName: 'bad-table-name',
+        },
+      };
+
+      errors = ServerlessConvention.checkDynamoDBTableName(
+        resource,
+        ServerlessConvention.serverless.service.getServiceName()
+      );
+      expect(errors.pop()).toMatch('does not start with the service name');
+    });
+
+    test('Correct table name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+      ServerlessConvention.serverless.service.getServiceName = jest
+        .fn()
+        .mockReturnValue('test-name');
+
+      // DynamoDB table name should be in snake case
+      const resource: CloudFormationResource = {
+        Type: 'AWS::DynamoDB::Table',
+        Properties: {
+          tableName: 'test-name-good-table-name',
+        },
+      };
+
+      let errors = ServerlessConvention.checkDynamoDBTableName(
+        resource,
+        ServerlessConvention.serverless.service.getServiceName()
+      );
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test node version', () => {
+    test('Different node versions', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      let errors = ServerlessConvention.checkNodeVersion(
+        'nodejs14.x',
+        'node12'
+      );
+      expect(errors.pop()).toMatch('does not match esbuild node version');
+    });
+
+    test('Same node version', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      let errors = ServerlessConvention.checkNodeVersion(
+        'nodejs14.x',
+        'node14'
+      );
+      expect(errors.length).toBe(0);
+    });
+  });
 });

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -176,7 +176,11 @@ describe('Test conventions plugin', () => {
       let ServerlessConvention = createServerlessConvention();
 
       // Ignore stage name check
-      ServerlessConvention.conventionsConfig.ignore.stageName = true;
+      ServerlessConvention.conventionsConfig = {
+        ignore: {
+          stageName: true,
+        },
+      };
 
       ServerlessConvention.serverless.service.provider.stage =
         'NotAGoodStageName';
@@ -188,9 +192,13 @@ describe('Test conventions plugin', () => {
 
     test('Initialize function ignore handler name check', async () => {
       let ServerlessConvention = createServerlessConvention();
+
       // Ignore the service name check
-      ServerlessConvention.conventionsConfig.ignore.handlerNameMatchesFunction =
-        true;
+      ServerlessConvention.conventionsConfig = {
+        ignore: {
+          handlerNameMatchesFunction: true,
+        },
+      };
 
       // Handler does not match function name (this should be ignored so test should still pass)
       let fn: Serverless.FunctionDefinitionHandler = {

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -275,14 +275,18 @@ describe('Test conventions plugin', () => {
       let errors = ServerlessConvention.checkStageName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
 
       // Contains non-alphabet character
       ServerlessConvention.serverless.service.provider.stage = '5tg';
       errors = ServerlessConvention.checkStageName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
 
       // Longer than 3 characters
       ServerlessConvention.serverless.service.provider.stage = 'test';
@@ -304,7 +308,9 @@ describe('Test conventions plugin', () => {
         ServerlessConvention.serverless.service
       );
       expect(errors.pop()).toMatch('must be 3 characters long');
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
     });
 
     test('Correct stage name', async () => {

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -4,7 +4,7 @@ import { CloudFormationResource } from 'serverless/plugins/aws/provider/awsProvi
 
 function createExampleServerless(): Serverless {
   const options: Serverless.Options = {
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
   };
 
@@ -16,7 +16,7 @@ function createExampleServerless(): Serverless {
   let serverless: Serverless = new Serverless({ options });
 
   serverless.cli = cli;
-  serverless.service.provider.stage = 'test';
+  serverless.service.provider.stage = 'tst';
   serverless.service.initialServerlessConfig = {};
   // Return a service name
   serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
@@ -26,7 +26,7 @@ function createExampleServerless(): Serverless {
       Resources: {},
     },
     name: 'aws',
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
     versionFunctions: false,
     runtime: 'nodejs14.x',
@@ -65,7 +65,7 @@ function createServerlessConvention(): ServerlessConventions {
   // Create a valid serverless instance
   const serverless: Serverless = createExampleServerless();
   const options: Serverless.Options = {
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
   };
 
@@ -133,7 +133,7 @@ describe('Test conventions plugin', () => {
       // Create another serverless instance with bad data
       const BadServerlessConvention: ServerlessConventions =
         new ServerlessConventions(serverless, {
-          stage: 'test',
+          stage: 'BadStageName',
           region: 'ap-southeast-2',
         });
 
@@ -148,6 +148,7 @@ describe('Test conventions plugin', () => {
       ServerlessConvention.conventionsConfig = {
         ignore: {
           serviceName: true,
+          stageName: true,
           handlerName: true,
           functionName: true,
           handlerNameMatchesFunction: true,
@@ -171,7 +172,21 @@ describe('Test conventions plugin', () => {
       }).not.toThrowError();
     });
 
-    test('Initialize function ignore service name check', async () => {
+    test('Initialize function ignore stage name check', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      // Ignore stage name check
+      ServerlessConvention.conventionsConfig.ignore.stageName = true;
+
+      ServerlessConvention.serverless.service.provider.stage =
+        'NotAGoodStageName';
+
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
+    });
+
+    test('Initialize function ignore handler name check', async () => {
       let ServerlessConvention = createServerlessConvention();
       // Ignore the service name check
       ServerlessConvention.conventionsConfig.ignore.handlerNameMatchesFunction =
@@ -228,14 +243,14 @@ describe('Test conventions plugin', () => {
       expect(errors.pop()).toMatch('not include the word "service"');
       expect(errors.pop()).toMatch('is not kebab case');
 
-      // Both not kebab case and word "service" in the name
+      // Longer than 23 characters
       ServerlessConvention.serverless.service.getServiceName = function () {
         return 'thisnameisverylongitshouldnotbethislongorelseitwontbeavalidname';
       };
       errors = ServerlessConvention.checkServiceName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('name must be less than');
+      expect(errors.pop()).toMatch('must be less than 23 characters');
     });
 
     test('Correct service name', async () => {
@@ -247,6 +262,59 @@ describe('Test conventions plugin', () => {
       let errors = ServerlessConvention.checkServiceName(
         ServerlessConvention.serverless.service
       );
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test stage name checker', () => {
+    test('Incorrect stage name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      // Not in lower case
+      ServerlessConvention.serverless.service.provider.stage = 'Dev';
+      let errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+
+      // Contains non-alphabet character
+      ServerlessConvention.serverless.service.provider.stage = '5tg';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+
+      // Longer than 3 characters
+      ServerlessConvention.serverless.service.provider.stage = 'test';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+
+      // Shorter than 3 characters
+      ServerlessConvention.serverless.service.provider.stage = 't';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+
+      // Both not lower case alphabets only and not 3 characters in length
+      ServerlessConvention.serverless.service.provider.stage = 'testService';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+    });
+
+    test('Correct stage name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      ServerlessConvention.serverless.service.provider.stage = 'prd';
+      let errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+
       expect(errors.length).toBe(0);
     });
   });


### PR DESCRIPTION
I’ve added this check to our convention plugin. The restrictions are:

- Stage must be exactly 3 characters long.
- Stage must be alphabet only and in lower case for consistency. Stages like `d3v` or `prD` will not work.

Apart from the changes above, I also added prettier configs & refactor a bit. The real changes happens in the last 2 commits: 
- [MICRO-27: Restrict stage to be 3 characters and only lower case alpha…](https://github.com/aligent/serverless-conventions/commit/b65dfaebbb000c809a116d25f990fc6eb0a4d7be)
- [MICRO-27: Update ReadMe with new stage restriction](https://github.com/aligent/serverless-conventions/commit/76eedc1667df603f734037f345a87ef8f5796c05)
