### PR TITLE
MICRO-27: Restrict stage name to only 3 alphabet characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A [Serverless framework](https://www.serverless.com) plugin to enforce various f
 | Service name must be dash delimited | this-is-a-good-name | thisIsABadName |
 | Service name must not contain the word "service" | this-is-a-good-name | this-is-a-bad-service | 
 | Service name must be less than 24 characters | this-is-a-good-name | this-is-a-bad-name-because-its-too-long |
+| Stage must contains only lower case alphabet characters | dev | Development |
+| Stage must be exactly 3 characters long | prd | prod |
 | Handler names must have the same name as the function | functions:<br>&nbsp;thisIsAWellNamedExample:<br>&nbsp;&nbsp;handler: src/this-is-a-well-named-example.handler | functions:<br>&nbsp;thisIsABadlyNamedFunction:<br>&nbsp;&nbsp;handler: src/this-is-a-badly-named-example.handler |
 | Function names must be in camel case | thisIsAWellNamedExample | ThisIsABadlyNamedExample |
 | Handler names must be dash delimited | src/this-is-a-well-named-example.handler | src/ThisIsABadlyNamedExample.handler |
@@ -35,6 +37,7 @@ A list of all the available ignore commands are below:
 conventions:
   ignore:
     serviceName: true
+    stageName: true
     handlerName: true
     functionName: true
     handlerNameMatchesFunction: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Service from 'serverless/classes/Service';
 type ConventionsConfig = {
   ignore?: {
     serviceName?: boolean;
+    stageName?: boolean;
     handlerName?: boolean;
     functionName?: boolean;
     handlerNameMatchesFunction?: boolean;
@@ -66,6 +67,10 @@ export default class ServerlessConventions {
     errors = this.conventionsConfig.ignore.serviceName
       ? errors
       : errors.concat(this.checkServiceName(this.serverless.service));
+
+    errors = this.conventionsConfig.ignore.stageName
+      ? errors
+      : errors.concat(this.checkStageName(this.serverless.service));
 
     const functionNames = this.serverless.service.getAllFunctions();
     functionNames.forEach((fnName) => {
@@ -146,13 +151,39 @@ export default class ServerlessConventions {
     // Check that the service name does not contain the word "service"
     if (serviceName.toLowerCase().includes('service')) {
       errors.push(
-        `Warning: Service name should not include the word "service"`
+        `Warning: Service name "${serviceName}" should not include the word "service"`
       );
     }
 
     // Check the length of the service name is not greater than x
     if (serviceName.length > 23) {
-      errors.push(`Warning: Service name must be less than 23 characters`);
+      errors.push(
+        `Warning: Service name "${serviceName}" must be less than 23 characters`
+      );
+    }
+
+    return errors;
+  }
+
+  // Stage name validation
+  // Must contains only lower case alphabet characters
+  // Must be only 3 characters
+  checkStageName(service: Service): Array<string> {
+    let errors: Array<string> = [];
+    const stageName = service.provider.stage;
+
+    // Check that the stage name contains only lower case alphabet characters (a-z)
+    if (stageName.match(/[^a-z]/)) {
+      errors.push(
+        `Warning: Stage name "${stageName}" should contains only alphabet characters in lower case`
+      );
+    }
+
+    // Check the length of the stage name is 3 characters
+    if (stageName.length !== 3) {
+      errors.push(
+        `Warning: Stage name "${stageName}" must be 3 characters long`
+      );
     }
 
     return errors;

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export default class ServerlessConventions {
   }
 
   // Stage name validation
-  // Must contains only lower case alphabet characters
+  // Must contain only lower case alphabet characters
   // Must be only 3 characters
   checkStageName(service: Service): Array<string> {
     let errors: Array<string> = [];
@@ -175,7 +175,7 @@ export default class ServerlessConventions {
     // Check that the stage name contains only lower case alphabet characters (a-z)
     if (stageName.match(/[^a-z]/)) {
       errors.push(
-        `Warning: Stage name "${stageName}" should contains only alphabet characters in lower case`
+        `Warning: Stage name "${stageName}" should only contain alphabet characters in lower case`
       );
     }
 

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -275,14 +275,18 @@ describe('Test conventions plugin', () => {
       let errors = ServerlessConvention.checkStageName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
 
       // Contains non-alphabet character
       ServerlessConvention.serverless.service.provider.stage = '5tg';
       errors = ServerlessConvention.checkStageName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
 
       // Longer than 3 characters
       ServerlessConvention.serverless.service.provider.stage = 'test';
@@ -304,7 +308,9 @@ describe('Test conventions plugin', () => {
         ServerlessConvention.serverless.service
       );
       expect(errors.pop()).toMatch('must be 3 characters long');
-      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+      expect(errors.pop()).toMatch(
+        'only contain alphabet characters in lower case'
+      );
     });
 
     test('Correct stage name', async () => {

--- a/tests/conventions.test.ts
+++ b/tests/conventions.test.ts
@@ -4,7 +4,7 @@ import { CloudFormationResource } from 'serverless/plugins/aws/provider/awsProvi
 
 function createExampleServerless(): Serverless {
   const options: Serverless.Options = {
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
   };
 
@@ -16,7 +16,7 @@ function createExampleServerless(): Serverless {
   let serverless: Serverless = new Serverless({ options });
 
   serverless.cli = cli;
-  serverless.service.provider.stage = 'test';
+  serverless.service.provider.stage = 'tst';
   serverless.service.initialServerlessConfig = {};
   // Return a service name
   serverless.service.getServiceName = jest.fn().mockReturnValue('test-name');
@@ -26,7 +26,7 @@ function createExampleServerless(): Serverless {
       Resources: {},
     },
     name: 'aws',
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
     versionFunctions: false,
     runtime: 'nodejs14.x',
@@ -65,7 +65,7 @@ function createServerlessConvention(): ServerlessConventions {
   // Create a valid serverless instance
   const serverless: Serverless = createExampleServerless();
   const options: Serverless.Options = {
-    stage: 'test',
+    stage: 'tst',
     region: 'ap-southeast-2',
   };
 
@@ -133,7 +133,7 @@ describe('Test conventions plugin', () => {
       // Create another serverless instance with bad data
       const BadServerlessConvention: ServerlessConventions =
         new ServerlessConventions(serverless, {
-          stage: 'test',
+          stage: 'BadStageName',
           region: 'ap-southeast-2',
         });
 
@@ -148,6 +148,7 @@ describe('Test conventions plugin', () => {
       ServerlessConvention.conventionsConfig = {
         ignore: {
           serviceName: true,
+          stageName: true,
           handlerName: true,
           functionName: true,
           handlerNameMatchesFunction: true,
@@ -171,7 +172,21 @@ describe('Test conventions plugin', () => {
       }).not.toThrowError();
     });
 
-    test('Initialize function ignore service name check', async () => {
+    test('Initialize function ignore stage name check', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      // Ignore stage name check
+      ServerlessConvention.conventionsConfig.ignore.stageName = true;
+
+      ServerlessConvention.serverless.service.provider.stage =
+        'NotAGoodStageName';
+
+      expect(() => {
+        ServerlessConvention.initialize();
+      }).not.toThrowError();
+    });
+
+    test('Initialize function ignore handler name check', async () => {
       let ServerlessConvention = createServerlessConvention();
       // Ignore the service name check
       ServerlessConvention.conventionsConfig.ignore.handlerNameMatchesFunction =
@@ -228,14 +243,14 @@ describe('Test conventions plugin', () => {
       expect(errors.pop()).toMatch('not include the word "service"');
       expect(errors.pop()).toMatch('is not kebab case');
 
-      // Both not kebab case and word "service" in the name
+      // Longer than 23 characters
       ServerlessConvention.serverless.service.getServiceName = function () {
         return 'thisnameisverylongitshouldnotbethislongorelseitwontbeavalidname';
       };
       errors = ServerlessConvention.checkServiceName(
         ServerlessConvention.serverless.service
       );
-      expect(errors.pop()).toMatch('name must be less than');
+      expect(errors.pop()).toMatch('must be less than 23 characters');
     });
 
     test('Correct service name', async () => {
@@ -247,6 +262,59 @@ describe('Test conventions plugin', () => {
       let errors = ServerlessConvention.checkServiceName(
         ServerlessConvention.serverless.service
       );
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Test stage name checker', () => {
+    test('Incorrect stage name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      // Not in lower case
+      ServerlessConvention.serverless.service.provider.stage = 'Dev';
+      let errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+
+      // Contains non-alphabet character
+      ServerlessConvention.serverless.service.provider.stage = '5tg';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+
+      // Longer than 3 characters
+      ServerlessConvention.serverless.service.provider.stage = 'test';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+
+      // Shorter than 3 characters
+      ServerlessConvention.serverless.service.provider.stage = 't';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+
+      // Both not lower case alphabets only and not 3 characters in length
+      ServerlessConvention.serverless.service.provider.stage = 'testService';
+      errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+      expect(errors.pop()).toMatch('must be 3 characters long');
+      expect(errors.pop()).toMatch('only alphabet characters in lower case');
+    });
+
+    test('Correct stage name', async () => {
+      let ServerlessConvention = createServerlessConvention();
+
+      ServerlessConvention.serverless.service.provider.stage = 'prd';
+      let errors = ServerlessConvention.checkStageName(
+        ServerlessConvention.serverless.service
+      );
+
       expect(errors.length).toBe(0);
     });
   });


### PR DESCRIPTION
With this restriction, the stage name must be:

- Exactly 3 characters long.
- Alphabet only and in lower case for consistency. Stages like `d3v` or `prD` will not work.