### PR TITLE
MICRO-29: Make sure ignore is defined when perform convention check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import Aws from 'serverless/plugins/aws/provider/awsProvider';
 import Service from 'serverless/classes/Service';
 
 type ConventionsConfig = {
-  ignore?: {
+  ignore: {
     serviceName?: boolean;
     stageName?: boolean;
     handlerName?: boolean;
@@ -48,16 +48,14 @@ export default class ServerlessConventions {
       },
     });
 
-    this.conventionsConfig =
-      this.serverless.service.initialServerlessConfig.conventions;
+    // Make sure `conventionsConfig` is defined in case `serverless.yml` only has empty `conventions` block
+    this.conventionsConfig = this.serverless.service.initialServerlessConfig
+      .conventions || {
+      ignore: {},
+    };
 
-    // Make sure ignore is defined to prevent errors being from being thrown when referencing children
-    if (this.conventionsConfig === undefined) {
-      this.conventionsConfig = {};
-    }
-    if (this.conventionsConfig.ignore === undefined) {
-      this.conventionsConfig.ignore = {};
-    }
+    // Make sure `ignore` is defined in case `serverless.yml` has `conventions` with an empty `ignore` block
+    this.conventionsConfig.ignore = this.conventionsConfig.ignore || {};
   }
 
   initialize() {


### PR DESCRIPTION
Revisit and fix some few issues related to ignore flags while performing convention check. This PR fix the following problems:

- `conventions` is specified in `serverless.yml` without `ignore` => `TypeError: Cannot read properties of null (reading 'ignore')`
- `conventions` is specified in `serverless.yml` with empty `ignore` => `TypeError: Cannot read properties of null (reading 'serviceName')`
- Make `ignore` mandatory so TypeScript won't complain about possible undefined object.

![image-20221010-062539](https://user-images.githubusercontent.com/108910975/194809228-d227097d-15f4-4816-b912-2fc1556ca691.png)
