### PR TITLE
feat: add check to ensure function name is the same as the serverless…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A [Serverless framework](https://www.serverless.com) plugin to enforce various f
 | Stage must be exactly 3 characters long | prd | prod |
 | Handler names must have the same name as the function | functions:<br>&nbsp;thisIsAWellNamedExample:<br>&nbsp;&nbsp;handler: src/this-is-a-well-named-example.handler | functions:<br>&nbsp;thisIsABadlyNamedFunction:<br>&nbsp;&nbsp;handler: src/this-is-a-badly-named-example.handler |
 | Function names must be in camel case | thisIsAWellNamedExample | ThisIsABadlyNamedExample |
+| Function names should not be overwritten | functions:<br>&nbsp;exampleFunction:<br>&nbsp;&nbsp;handler: src/example-function.handler | functions:<br>&nbsp;exampleFunction:<br>&nbsp;&nbsp;name: exampleFunction<br>&nbsp;&nbsp;handler: src/example-function.handler |
 | Handler names must be dash delimited | src/this-is-a-well-named-example.handler | src/ThisIsABadlyNamedExample.handler |
 | Handler names must end in ".handler" | src/this-is-a-well-named-example.handler | src/this-is-a-badly-named-example |
 | DynamoDB table names must be in kebab case | example-name-good-table-name | BadTableName |

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,7 @@ export default class ServerlessConventions {
 
   // Function name conventions
   // Must be camelCase
+  // Must use the default function name
   checkFunctionName(fn: Serverless.FunctionDefinitionHandler): Array<string> {
     let errors: Array<string> = [];
     // Get the function name and strip the service name and stage from it
@@ -230,8 +231,20 @@ export default class ServerlessConventions {
       .pop() as string;
 
     // Check that the function name is in camel case
-    if (fnName !== camelCase(fnName)) {
+    if (fnName !== undefined && fnName !== camelCase(fnName)) {
       errors.push(`Warning: Function "${fnName}" is not camel case`);
+    }
+
+    // Check the name hasn't been overwritten with a custom name parameter
+    let expectedFnName = [
+      this.serverless.service.getServiceName(),
+      this.serverless.service.provider.stage,
+      fnName,
+    ].join('-');
+    if (fn.name !== expectedFnName) {
+      errors.push(
+        `Warning: Function "${fnName}" is not using the default name. Remove the custom name property from the function.`
+      );
     }
 
     return errors;


### PR DESCRIPTION
By default, serverless automatically names functions by prepending the service name and stage to the function name. As an example:

service: example-name

provider:
  stage: staging

functions:
  hello:
    handler: src/hello.handler
Is given the function name example-name-staging-hello

This behavior can be overwritten:

service: example-name

provider:
  stage: staging

functions:
  hello:
    name: ${self:service}-hello
    handler: src/hello.handler
Which would result in example-name-hello

Overriding the function name can cause issues when it comes to checking if the function name is in camel case.
DO-1277