### PR TITLE
MICRO-66:  More visible log out put when an error occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/serverless-conventions",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "A Serverless framework plugin to enforce various formatting conventions to maintain consistency within Serverless applications.",
   "main": "lib/index.js",
   "types": "index.d.ts",
@@ -32,7 +32,7 @@
     "@types/jest": " ^27.0.2"
   },
   "peerDependencies": {
-    "serverless": "2 || 3"
+    "serverless": "3.x"
   },
   "engines": {
     "node": ">=10.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,8 @@ export default class ServerlessConventions implements ServerlessPlugin {
     this.conventionsConfig.ignore = this.conventionsConfig.ignore || {};
 
     // Notify user if they are using unsupported Serverless version
-    const version = parseFloat(this.serverless.getVersion());
-    if (version < 3) {
+    const version = this.serverless.getVersion();
+    if (parseFloat(version) < 3) {
       this.log.warning(
         `You are using an old Serverless version (${version}).\n` +
           `Please consider to upgrade Serverless or downgrade this plugin to v0.4.1`
@@ -125,8 +125,12 @@ export default class ServerlessConventions implements ServerlessPlugin {
 
     // If there were errors detected, print out a list and throw an error
     if (errors.length !== 0) {
+      errors.forEach((error) => {
+        this.log.error(chalk.red(error));
+      });
+
       throw new this.serverless.classes.Error(
-        'Serverless conventions validation failed!\n' + errors.join('\n')
+        'Serverless conventions validation failed!\n ✖ ' + errors.join('\n ✖ ')
       );
     }
 
@@ -146,21 +150,21 @@ export default class ServerlessConventions implements ServerlessPlugin {
     // Check that the service name is in kebab case
     if (serviceName !== kebabCase(serviceName)) {
       errors.push(
-        `✖ Warning: Service name "${serviceName}" is not kebab case (dash delimited)`
+        `Error: Service name "${serviceName}" is not kebab case (dash delimited)`
       );
     }
 
     // Check that the service name does not contain the word "service"
     if (serviceName.toLowerCase().includes('service')) {
       errors.push(
-        `✖ Warning: Service name "${serviceName}" should not include the word "service"`
+        `Error: Service name "${serviceName}" should not include the word "service"`
       );
     }
 
     // Check the length of the service name is not greater than x
     if (serviceName.length > 23) {
       errors.push(
-        `✖ Warning: Service name "${serviceName}" must be less than 23 characters`
+        `Error: Service name "${serviceName}" must be less than 23 characters`
       );
     }
 
@@ -177,15 +181,13 @@ export default class ServerlessConventions implements ServerlessPlugin {
     // Check that the stage name contains only lower case alphabet characters (a-z)
     if (stageName.match(/[^a-z]/)) {
       errors.push(
-        `✖ Warning: Stage name "${stageName}" should only contain alphabet characters in lower case`
+        `Error: Stage name "${stageName}" should only contain alphabet characters in lower case`
       );
     }
 
     // Check the length of the stage name is 3 characters
     if (stageName.length !== 3) {
-      errors.push(
-        `✖ Warning: Stage name "${stageName}" must be 3 characters long`
-      );
+      errors.push(`Error: Stage name "${stageName}" must be 3 characters long`);
     }
 
     return errors;
@@ -210,15 +212,13 @@ export default class ServerlessConventions implements ServerlessPlugin {
     // Check that the handler name is in kebab case
     if (handlerNameNoExtension !== kebabCase(handlerNameNoExtension)) {
       errors.push(
-        `✖ Warning: Handler "${handlerName}" is not kebab case (dash delimited)`
+        `Error: Handler "${handlerName}" is not kebab case (dash delimited)`
       );
     }
 
     // Check that the handler ends in .handler
     if (handlerNameNoExtension === handlerName) {
-      errors.push(
-        `✖ Warning: Handler "${handlerName}" does not end in ".handler"`
-      );
+      errors.push(`Error: Handler "${handlerName}" does not end in ".handler"`);
     }
 
     return errors;
@@ -236,7 +236,7 @@ export default class ServerlessConventions implements ServerlessPlugin {
 
     // Check that the function name is in camel case
     if (fnName !== undefined && fnName !== camelCase(fnName)) {
-      errors.push(`✖ Warning: Function "${fnName}" is not camel case`);
+      errors.push(`Error: Function "${fnName}" is not camel case`);
     }
 
     // Check the name hasn't been overwritten with a custom name parameter
@@ -247,7 +247,7 @@ export default class ServerlessConventions implements ServerlessPlugin {
     ].join('-');
     if (fn.name !== expectedFnName) {
       errors.push(
-        `✖ Warning: Function "${fnName}" is not using the default name. Remove the custom name property from the function.`
+        `Error: Function "${fnName}" is not using the default name. Remove the custom name property from the function.`
       );
     }
 
@@ -277,7 +277,7 @@ export default class ServerlessConventions implements ServerlessPlugin {
       kebabCase(fnName) !== kebabCase(handler)
     ) {
       errors.push(
-        `✖ Warning: Function "${fnName}" does not match handler name "${handler}.handler"`
+        `Error: Function "${fnName}" does not match handler name "${handler}.handler"`
       );
     }
 
@@ -302,14 +302,14 @@ export default class ServerlessConventions implements ServerlessPlugin {
 
     if (tableName == tableNameWithoutService) {
       errors.push(
-        `✖ Warning: DynamoDB table name "${tableName}" does not start with the service name`
+        `Error: DynamoDB table name "${tableName}" does not start with the service name`
       );
     }
 
     // Check that the function name is in snake case
     if (tableName !== kebabCase(tableName)) {
       errors.push(
-        `✖ Warning: DynamoDB table name "${tableName}" is not kebab case`
+        `Error: DynamoDB table name "${tableName}" is not kebab case`
       );
     }
 
@@ -333,7 +333,7 @@ export default class ServerlessConventions implements ServerlessPlugin {
 
     if (providerVersionNum !== esBuildVersionNum) {
       errors.push(
-        `✖ Warning: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`
+        `Error: Provider node runtime version "${providerVersion}" does not match esbuild node version "${esBuildVersion}"`
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,15 @@ export default class ServerlessConventions implements ServerlessPlugin {
 
     // Make sure `ignore` is defined in case `serverless.yml` has `conventions` with an empty `ignore` block
     this.conventionsConfig.ignore = this.conventionsConfig.ignore || {};
+
+    // Notify user if they are using unsupported Serverless version
+    const version = parseFloat(this.serverless.getVersion());
+    if (version < 3) {
+      this.log.warning(
+        `You are using an old Serverless version (${version}).\n` +
+          `Please consider to upgrade Serverless or downgrade this plugin to v0.4.1`
+      );
+    }
   }
 
   runConventionCheck() {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -11,7 +11,7 @@ export interface ServerlessErrorConstructor {
 }
 
 export interface ServerlessClasses extends Serverless {
-  classes: { Error: ServerlessErrorConstructor };
+  classes?: { Error: ServerlessErrorConstructor };
 }
 
 export type ConventionsConfig = {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,0 +1,26 @@
+import Serverless from 'serverless';
+
+interface ServerlessError extends Error {
+  code: string;
+}
+
+export interface ServerlessErrorConstructor {
+  new (message?: string): ServerlessError;
+  (message?: string): ServerlessError;
+  readonly prototype: ServerlessError;
+}
+
+export interface ServerlessClasses extends Serverless {
+  classes: { Error: ServerlessErrorConstructor };
+}
+
+export type ConventionsConfig = {
+  ignore: {
+    serviceName?: boolean;
+    stageName?: boolean;
+    handlerName?: boolean;
+    functionName?: boolean;
+    handlerNameMatchesFunction?: boolean;
+    dynamoDBTableName?: boolean;
+  };
+};


### PR DESCRIPTION
Conventions plugin warnings during deployment tend to be hidden in the verbose deploy log. This is exacerbated by the actual failure error appearing at the end of the CLI output, which makes it seem like the related warning should be just above it. This PR address this issue with some improvements:

1. We will now drop Serverless v2.x support and a warning will show if it is use with a deprecated version.

2. Main logic is now in `runConventionCheck()` function as `initialize()` function is for property initialisation. Some of serverless variables (eg: params, env, etc.) may not available before `initialize` lifecycle event.
3. We now use Serverless logging class instead of deprecated `serverless.cli.log()` .
4. We now throw error and have it properly formatted by use Serverless' error class instead of printing error messages manually.
   a. This ensure that all the errors messages are included in the main error and will not be 'hidden' in the deploy log (regardless `--verbose` flag is set or not).
   b. A down side of this approach is that we cannot colour these messages in `red` as we do before.
![image](https://github.com/aligent/serverless-conventions/assets/108910975/2abcb3cb-43f6-4aeb-89fe-e340f6dd5382)


