### PR TITLE
Update NPM token secret in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - run: npm run build
     - run: npm publish --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     - run: git push
       env:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description of the proposed changes**
Feels like we should be using the GH Global secret thats 3 months old vs the 5yr old one specific to this repo?

**Screenshots (if applicable)**
<img width="1072" height="1025" alt="Screenshot 2026-03-05 at 1 25 51 pm" src="https://github.com/user-attachments/assets/969e3c3e-d3e6-4d9a-82a8-bd3303970be7" />

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

